### PR TITLE
feat: add GenerateDataKey permissions

### DIFF
--- a/.github/workflows/format-tests.yaml
+++ b/.github/workflows/format-tests.yaml
@@ -6,7 +6,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: quay.io/3scale/soyuz:v0.3.0-ci
+    container: quay.io/3scale/soyuz:v4.5.0-ci
     steps:
       - uses: actions/checkout@v2
 

--- a/replica_kms.tf
+++ b/replica_kms.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "kms_replica" {
 
     sid       = "Enable Cross Account Encrypt access for S3 Replication"
     effect    = "Allow"
-    actions   = ["kms:Encrypt"]
+    actions   = ["kms:GenerateDataKey", "kms:Encrypt"]
     resources = ["*"]
 
     principals {

--- a/replication_iam.tf
+++ b/replication_iam.tf
@@ -144,7 +144,8 @@ data "aws_iam_policy_document" "replication" {
   # and not the object ARN, for example, arn:aws:s3:::bucket_ARN.
   statement {
     actions = [
-      "kms:Decrypt"
+      "kms:Decrypt",
+      "kms:GenerateDataKey"
     ]
     effect = "Allow"
     condition {
@@ -166,7 +167,8 @@ data "aws_iam_policy_document" "replication" {
   # and not the object ARN, for example, arn:aws:s3:::bucket_ARN.
   statement {
     actions = [
-      "kms:Encrypt"
+      "kms:Encrypt",
+      "kms:GenerateDataKey"
     ]
     effect = "Allow"
     condition {

--- a/replication_iam.tf
+++ b/replication_iam.tf
@@ -35,11 +35,15 @@ data "aws_iam_policy_document" "s3_assume" {
     ]
 
     principals {
-      type        = "Service"
-      identifiers = ["s3.amazonaws.com"]
+      type = "Service"
+      identifiers = [
+        "s3.amazonaws.com",
+        "batchoperations.s3.amazonaws.com"
+      ]
     }
   }
 }
+
 
 # master-replica replication IAM policy ----------------------------------------
 resource "aws_iam_policy" "replication" {
@@ -57,6 +61,30 @@ resource "aws_iam_policy" "replication" {
 
 # master-replica replication IAM policy document -------------------------------
 data "aws_iam_policy_document" "replication" {
+
+  # https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-batch-replication-policies.html
+  statement {
+    sid    = "AllowPrimaryToInitiateReplication"
+    effect = "Allow"
+    actions = [
+      "s3:InitiateReplication"
+    ]
+    resources = [
+      format("arn:aws:s3:::%s/*", local.master_bucket_id)
+    ]
+  }
+
+  statement {
+    sid    = "AllowPrimaryToBatchReplication"
+    effect = "Allow"
+    actions = [
+      "s3:PutInventoryConfiguration",
+      "s3:GetReplicationConfiguration"
+    ]
+    resources = [
+      format("arn:aws:s3:::%s", local.master_bucket_id)
+    ]
+  }
 
   # s3:GetReplicationConfiguration and s3:ListBucket—Permissions
   # for these actions on the source bucket allow Amazon S3


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PRs adds the GenerateDataKey permissions required for the replication after some changes in the AWS side. 

It also adds the required permissions for batch replication jobs.

#### Does this PR introduce a user-facing change?

```release-note
- Adds required permission for batch replication
- Adds GenerateDataKey permission for rule based replication
```

